### PR TITLE
sync merge : fix modname and use intlib depennds only in older engine

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -6,6 +6,7 @@ mobs_monster?
 3d_armor?
 toolranks?
 moreblocks?
+intllib?
 vessels?
 nc_fire?
 mcl_armor?

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 lavastuff = {}
 
-local MODPATH = minetest.get_modpath("lavastuff")
+local MODPATH = minetest.get_modpath(minetest.get_current_modname())
 
 local COOLDOWN = dofile(MODPATH.."/cooldowns.lua")
 local S
@@ -34,7 +34,7 @@ else
 		function minetest.get_translator(textdomain)
 			return function(str, ...) return  minetest.translate(textdomain or "", str, ...) end
 		end
-		S = minetest.get_translator("mobs")
+		S = minetest.get_translator(minetest.get_current_modname())
 	end
 end
 


### PR DESCRIPTION
[fix modname and use intlib depennds only in older engines](https://github.com/minenux/minetest-mod-lavastuff/commit/9cac4ad93195a50ab2a1a0c4292d0ac329bef730)

* autodetect mod name from minetest api
* added only intllib in depends.txt for older 0.4.X, mod.conf its for 5+
  so due 5+ has built in internationalization its not necesary in that file